### PR TITLE
Guard pypar.balance() against out-of-range index and also stop importing math

### DIFF
--- a/src/pypar.py
+++ b/src/pypar.py
@@ -488,6 +488,8 @@ def balance(N, P, p):
 
     L = int(floor(float(N) / P))
     K = N - P * L
+    if p >= P:
+        return N, N
     if p < K:
         Nlo = p * L + p
         Nhi = Nlo + L + 1

--- a/src/pypar.py
+++ b/src/pypar.py
@@ -484,12 +484,12 @@ def balance(N, P, p):
     list slicing such that the last element of Nlo:Nhi is, in fact, Nhi-1
     """
 
-    from math import floor
-
-    L = int(floor(float(N) / P))
-    K = N - P * L
+    N = int(N)
+    P = int(P)
+    p = int(p)
     if p >= P:
         return N, N
+    L, K = N // P, N % P
     if p < K:
         Nlo = p * L + p
         Nhi = Nlo + L + 1


### PR DESCRIPTION
In this two commits, I did some minor revisions on `pypar.balance()` function.

The 1st one guards the argument `p` against out-of-bound values, and returns `(N, N)`.  This return value is natural because `N:N` is a valid slice of zero-length, which is expected, and also because this is a natural continuation of the return values from valid input values, and finally, such is already the case when `balance(N, P, p)` is called when `P > N`.

In the 2nd commit, `from math import floor` is no longer used, as with conversions to `float`.  They're not necessary, and are much slower than integer arithmetics.  To get the quotient and remainder, Python's built-in operators `//` and `%` are enough.  This is even faster than `divmod()`.