### PR TITLE
mpiext.c: remove unsafe sprintf() calls and reduce code duplication.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libopenmpi-dev openmpi-bin
 install:
-  - pip install tblib --use-mirrors
-  - pip install six --use-mirrors
+  - pip install tblib
+  - pip install six
   - pip install .
 # command to run tests
 script:


### PR DESCRIPTION
sprintf() calls that fill an error-message buffer with string
interpolation are replaced with safer snprintf() calls.  The messages
may be truncated.

Also, some duplicate exception-raising codes are cleaned up.
