### PR TITLE
Remove unsafe string formatting (sprintf) when forming error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libopenmpi-dev openmpi-bin
 install:
-  - pip install tblib --use-mirrors
-  - pip install six --use-mirrors
+  - pip install tblib
+  - pip install six
   - pip install .
 # command to run tests
 script:


### PR DESCRIPTION
Remove potentially buffer-overflowing calls to `sprintf` when formatting error messages.

Instead, use `PyErr_Format` to set Python exception with formatted message.